### PR TITLE
Jdurrell/staging environment

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,7 +3,7 @@ name: Deploy Production API
 on:
 push:
     branches:
-    - production
+      - production
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,6 +1,9 @@
 name: Deploy Production API
 
 on:
+push:
+    branches:
+    - production
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       SERVICE: ${{ secrets.GCP_PRODUCTION_SERVICE_NAME }}
-      IMAGE_NAME: us-east4-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_PRODUCTION_SERVICE_NAME }}/api-v3:${{ github.sha }}
+      IMAGE_NAME: us-east4-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/api-v3/${{ secrets.GCP_PRODUCTION_SERVICE_NAME }}:${{ github.sha }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3.3.0

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -2,7 +2,7 @@ name: Deploy Production API
 
 on:
   workflow_dispatch:
-  
+
 jobs:
   deploy:
     name: Deploy to Production
@@ -14,25 +14,25 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3.3.0
-      
+
     - id: 'auth'
       name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v1
       with:
-        credentials_json: ${{ secrets.GCP_PRODUCTION_SA_KEY }}
-        
+        credentials_json: ${{ secrets.GCP_DEPLOYER_SA_KEY }}
+
     - name: Setup Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
 
     - name: Authorize Docker Push
       run: gcloud auth configure-docker us-east4-docker.pkg.dev --quiet
-      
+
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v4.0.0
       with:
         push: true
         tags: ${{ env.IMAGE_NAME }}
-        
+
     - name: Deploy Cloud Run Service
       run: |-
         gcloud run deploy ${{ env.SERVICE }} \

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,7 @@ name: Deploy Staging API
 on:
   push:
     branches:
-    - main
+      - main
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,9 +1,6 @@
-name: Deploy Staging API
+name: Deploy Production API
 
 on:
-  push:
-    branches:
-    - dev
   workflow_dispatch:
   
 jobs:
@@ -13,39 +10,33 @@ jobs:
     env:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       SERVICE: ${{ secrets.GCP_STAGING_SERVICE_NAME }}
-      IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_STAGING_SERVICE_NAME }}:${{ github.sha }}
+      IMAGE_NAME: us-east4-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_STAGING_SERVICE_NAME }}/api-v3:${{ github.sha }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3.3.0
-      
+
     - id: 'auth'
       name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v1
       with:
-        credentials_json: ${{ secrets.GCP_STAGING_SA_KEY }}
-        
+        credentials_json: ${{ secrets.GCP_DEPLOYER_SA_KEY }}
+
     - name: Setup Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
 
     - name: Authorize Docker Push
-      run: gcloud auth configure-docker --quiet
-      
+      run: gcloud auth configure-docker us-east4-docker.pkg.dev --quiet
+
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v4.0.0
       with:
         push: true
         tags: ${{ env.IMAGE_NAME }}
-        
+
     - name: Deploy Cloud Run Service
       run: |-
         gcloud run deploy ${{ env.SERVICE }} \
-          --region "us-central1" \
+          --region "us-east4" \
           --image ${{ env.IMAGE_NAME }} \
           --platform "managed" \
           --quiet
-      
-      
-        
-      
-  
-    

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Production API
+name: Deploy Staging API
 
 on:
   workflow_dispatch:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       SERVICE: ${{ secrets.GCP_STAGING_SERVICE_NAME }}
-      IMAGE_NAME: us-east4-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_STAGING_SERVICE_NAME }}:${{ github.sha }}
+      IMAGE_NAME: us-east4-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/api-v3/${{ secrets.GCP_STAGING_SERVICE_NAME }}:${{ github.sha }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3.3.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -33,10 +33,10 @@ jobs:
         push: true
         tags: ${{ env.IMAGE_NAME }}
 
-    # - name: Deploy Cloud Run Service
-    #   run: |-
-    #     gcloud run deploy ${{ env.SERVICE }} \
-    #       --region "us-east4" \
-    #       --image ${{ env.IMAGE_NAME }} \
-    #       --platform "managed" \
-    #       --quiet
+    - name: Deploy Cloud Run Service
+      run: |-
+        gcloud run deploy ${{ env.SERVICE }} \
+          --region "us-east4" \
+          --image ${{ env.IMAGE_NAME }} \
+          --platform "managed" \
+          --quiet

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,6 +1,9 @@
 name: Deploy Staging API
 
 on:
+  push:
+    branches:
+    - main
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       SERVICE: ${{ secrets.GCP_STAGING_SERVICE_NAME }}
-      IMAGE_NAME: us-east4-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_STAGING_SERVICE_NAME }}/api-v3:${{ github.sha }}
+      IMAGE_NAME: us-east4-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_STAGING_SERVICE_NAME }}:${{ github.sha }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3.3.0
@@ -33,10 +33,10 @@ jobs:
         push: true
         tags: ${{ env.IMAGE_NAME }}
 
-    - name: Deploy Cloud Run Service
-      run: |-
-        gcloud run deploy ${{ env.SERVICE }} \
-          --region "us-east4" \
-          --image ${{ env.IMAGE_NAME }} \
-          --platform "managed" \
-          --quiet
+    # - name: Deploy Cloud Run Service
+    #   run: |-
+    #     gcloud run deploy ${{ env.SERVICE }} \
+    #       --region "us-east4" \
+    #       --image ${{ env.IMAGE_NAME }} \
+    #       --platform "managed" \
+    #       --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ COPY . .
 
 RUN yarn build
 
-# Set NODE_ENV to production
+# Set NODE_ENV to production to tell yarn to consider it a production installation with production dependencies.
+# (even though this may actually be building the staging version)
 ENV NODE_ENV production
 
 RUN yarn install --prod && yarn cache clean

--- a/knexfile.ts
+++ b/knexfile.ts
@@ -3,23 +3,6 @@ import type { Knex } from "knex";
 // Update with your config settings.
 
 const config: { [key: string]: Knex.Config } = {
-  development: {
-    client: "mysql",
-    connection: {
-      database: "",
-      user: "root",
-      password: "password",
-      port: 3306,
-      host: "localhost",
-    },
-    seeds: {
-      directory: "./db/seeds",
-    },
-    migrations: {
-      directory: "./db/migrations",
-    },
-  },
-
   staging: {
     client: "mysql",
     connection: {
@@ -43,23 +26,6 @@ const config: { [key: string]: Knex.Config } = {
     connection: {
       database: "production",
       user: "apiv3_production",
-      password: "",
-    },
-    pool: {
-      min: 2,
-      max: 10,
-    },
-    migrations: {
-      tableName: "knex_migrations",
-      directory: "./db/migrations",
-    },
-  },
-
-  test: {
-    client: "mysql",
-    connection: {
-      database: "test",
-      user: "apiv3_test",
       password: "",
     },
     pool: {

--- a/src/common/config/database.config.ts
+++ b/src/common/config/database.config.ts
@@ -5,7 +5,8 @@ import { Knex } from "knex";
 export const dbConfig = registerAs<Knex.StaticConnectionConfig>(
   ConfigToken.DB,
   () => {
-    if (process.env.NODE_ENV === "production") {
+    // Connect to the database via Unix socket if we are running on Cloud Run.
+    if (process.env.RUNTIME_INSTANCE === "production" || process.env.RUNTIME_INSTANCE === "staging") {
       return {
         user: process.env.MYSQL_USER,
         password: process.env.MYSQL_PASSWORD,
@@ -13,6 +14,7 @@ export const dbConfig = registerAs<Knex.StaticConnectionConfig>(
         socketPath: process.env.MYSQL_SOCKET_PATH,
       };
     } else {
+      // Otherwise, we are running locally, so connect to database over the Cloud SQL Auth Proxy.
       return {
         host: process.env.MYSQL_HOST,
         password: process.env.MYSQL_PASSWORD,

--- a/src/common/config/firebase.config.ts
+++ b/src/common/config/firebase.config.ts
@@ -6,27 +6,21 @@ import * as admin from "firebase-admin";
 export const firebaseConfig = registerAs<FirebaseConfig>(
   ConfigToken.GCP,
   () => {
+    // For local testing only: use service account for credentials.
+    // Ideally, we *should* be able to pass our own developer Application Default credentials
+    // into this instead of needing a service account. However, this turned out to be finnicky
+    // at the time, so we have opted to keep it like this for now.
+    // TODO: Figure out how to pass system application default credentials to this for local testing.
     if (process.env.GOOGLE_CERT) {
-      if (process.env.NODE_ENV && process.env.NODE_ENV === "production") {
-        const cert = JSON.parse(process.env.GOOGLE_CERT);
-        return {
-          credential: admin.credential.cert({
-            projectId: cert.project_id,
-            privateKey: cert.private_key,
-            clientEmail: cert.client_email,
-          }),
-          storageBucket: `${process.env.STORAGE_BUCKET}.appspot.com`,
-        };
-      } else {
-        // For local testing only:
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const serviceAccount = require(process.env.GOOGLE_CERT);
-        return {
-          credential: admin.credential.cert(serviceAccount),
-          storageBucket: `${process.env.STORAGE_BUCKET}.appspot.com`,
-        };
-      }
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const serviceAccount = require(process.env.GOOGLE_CERT);
+      return {
+        credential: admin.credential.cert(serviceAccount),
+        storageBucket: `${process.env.STORAGE_BUCKET}.appspot.com`,
+      };
     } else {
+      // Otherwise, use Application Default credentials. This should happen on the Cloud Run
+      // instances and use the service account associated with the respective instance.
       return {
         credential: admin.credential.applicationDefault(),
         projectId: process.env.GOOGLE_CLOUD_PROJECT,

--- a/src/common/docs/api-auth.decorator.ts
+++ b/src/common/docs/api-auth.decorator.ts
@@ -1,4 +1,3 @@
-import { Role } from "common/gcp";
 import { applyDecorators } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -7,6 +6,8 @@ import {
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
 import { ExceptionResponse } from "./exception-response.entity";
+
+import { Role } from "common/gcp";
 
 export const ApiAuth = (privilege: Role, restricted = false) => {
   return applyDecorators(

--- a/src/common/filters/DBExceptionFilter.ts
+++ b/src/common/filters/DBExceptionFilter.ts
@@ -15,12 +15,9 @@ export class DBExceptionFilter implements ExceptionFilter {
     const res = ctx.getResponse<Response>();
 
     if (exception instanceof UniqueViolationError) {
-      // if used during staging, show more details on error
-      if (
-        req.user &&
-        "aud" in req.user &&
-        req.user.aud === "hackpsu18-staging"
-      ) {
+      
+      // If used during staging, show more details on error.
+      if (process.env.NODE_ENV && process.env.NODE_ENV === "staging") {
         res.status(HttpStatus.CONFLICT).send({
           statusCode: HttpStatus.CONFLICT,
           message: exception.message,

--- a/src/common/filters/DBExceptionFilter.ts
+++ b/src/common/filters/DBExceptionFilter.ts
@@ -16,8 +16,9 @@ export class DBExceptionFilter implements ExceptionFilter {
 
     if (exception instanceof UniqueViolationError) {
       
-      // If used during staging, show more details on error.
-      if (process.env.NODE_ENV && process.env.NODE_ENV === "staging") {
+      // If not a production instance, we can give information for debugging purposes, so
+      // show more details on error.
+      if (process.env.RUNTIME_INSTANCE && process.env.RUNTIME_INSTANCE != "production") {
         res.status(HttpStatus.CONFLICT).send({
           statusCode: HttpStatus.CONFLICT,
           message: exception.message,

--- a/src/common/gcp/auth/firebase-auth.service.ts
+++ b/src/common/gcp/auth/firebase-auth.service.ts
@@ -27,11 +27,8 @@ export class FirebaseAuthService {
   constructor(private readonly httpService: HttpService, private readonly configService: ConfigService) {
     // Set Prod vs. Staging auth based on environment.
     this.authEnvironment = 
-      (process.env.NODE_ENV && process.env.NODE_ENV == "production") ? 
+      (process.env.RUNTIME_INSTANCE && process.env.RUNTIME_INSTANCE === "production") ? 
       AuthEnvironment.PROD : AuthEnvironment.STAGING;
-
-    // TEMPORARY HARDCODE FOR LOCAL TESTING. REMOVE BEFORE MERGING.
-    // this.authEnvironment = AuthEnvironment.PROD;
   }
 
   private decodeToken(token: string): FirebaseJwtPayload {

--- a/src/common/gcp/auth/firebase-auth.service.ts
+++ b/src/common/gcp/auth/firebase-auth.service.ts
@@ -11,11 +11,11 @@ import {
 import { Role } from "./firebase-auth.types";
 
 enum AuthEnvironment {
-  PROD = "PROD",
-  STAGING = "STAGING"
+  PROD = "production",
+  STAGING = "staging"
 }
 
-type FirebaseJwtPayload = JwtPayload & { PROD?: number, STAGING?: number };
+type FirebaseJwtPayload = JwtPayload & { production?: number, staging?: number };
 type ValidateFn = (user: any, role: Role) => boolean;
 type ValidateCmp = (role: Role) => boolean;
 
@@ -138,7 +138,6 @@ export class FirebaseAuthService {
   async updateUserPrivilege(uid: string, privilege: Role): Promise<void> {
     const privileges = ((await admin.auth().getUser(uid)).customClaims) ?? {};
     privileges[this.authEnvironment] = privilege;
-    delete privileges.privilege;  // REMOVE BEFORE MERGING. REMOVES PREVIOUS SETUP.
     await admin.auth().setCustomUserClaims(uid, privileges);
   }
 }

--- a/src/common/gcp/auth/firebase-auth.service.ts
+++ b/src/common/gcp/auth/firebase-auth.service.ts
@@ -85,21 +85,16 @@ export class FirebaseAuthService {
   ): Promise<boolean> {
     if (!access || !predicate) {
       // No predicated restrictions exist on this route, so block the request.
-      console.log("No predicate found.");
       return false;
     }
 
     // Block the request if the user doesn't meet any of the predicated roles.
-    console.log(access);
     const asfasdf = await this.getUserPrivilegeFromRequest(request);
-    console.log(asfasdf);
     if (!access.includes(await this.getUserPrivilegeFromRequest(request))) {
-      console.log("Blocked on roles.");
       return false;
     }
 
     // Roles are a potential match, so check the predicate to determine access.
-    console.log("Checking predicate.");
     return predicate(request);
   }
 
@@ -132,8 +127,6 @@ export class FirebaseAuthService {
     try {
       if (await this.validateUser(uid)) {
         const user = await admin.auth().getUser(uid);
-        console.log("Logging custom claims:")
-        console.log(user.customClaims);
         return user.customClaims[this.authEnvironment];
       } else {
         return Role.NONE;

--- a/src/common/gcp/auth/firebase-auth.service.ts
+++ b/src/common/gcp/auth/firebase-auth.service.ts
@@ -25,10 +25,10 @@ export class FirebaseAuthService {
   private authEnvironment: AuthEnvironment;
   
   constructor(private readonly httpService: HttpService, private readonly configService: ConfigService) {
-    // Set Prod vs. Staging auth based on environment.
-    this.authEnvironment = 
-      (process.env.RUNTIME_INSTANCE && process.env.RUNTIME_INSTANCE === "production") ? 
-      AuthEnvironment.PROD : AuthEnvironment.STAGING;
+    this.authEnvironment = configService.get<AuthEnvironment>("AUTH_ENVIRONMENT");
+    if (!(this.authEnvironment in AuthEnvironment)) {
+      throw Error(`Unrecognized AUTH_ENVIRONMENT: ${this.authEnvironment}`);
+    }
   }
 
   private decodeToken(token: string): FirebaseJwtPayload {

--- a/src/common/gcp/auth/firebase-auth.service.ts
+++ b/src/common/gcp/auth/firebase-auth.service.ts
@@ -1,110 +1,154 @@
-import { Injectable } from "@nestjs/common";
 import { HttpService } from "@nestjs/axios";
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import * as admin from "firebase-admin";
+import jwtDecode, { JwtPayload } from "jwt-decode";
+
 import {
   FirebaseAuthJWTKeySets,
   RestrictedEndpointPredicate,
 } from "common/gcp/auth";
 import { Role } from "./firebase-auth.types";
-import jwtDecode, { JwtPayload } from "jwt-decode";
-import * as admin from "firebase-admin";
 
-type FirebaseJwtPayload = JwtPayload & { privilege?: number };
+enum AuthEnvironment {
+  PROD = "PROD",
+  STAGING = "STAGING"
+}
 
+type FirebaseJwtPayload = JwtPayload & { PROD?: number, STAGING?: number };
 type ValidateFn = (user: any, role: Role) => boolean;
-
 type ValidateCmp = (role: Role) => boolean;
 
 @Injectable()
 export class FirebaseAuthService {
-  constructor(private readonly httpService: HttpService) {}
+  
+  private authEnvironment: AuthEnvironment;
+  
+  constructor(private readonly httpService: HttpService, private readonly configService: ConfigService) {
+    // Set Prod vs. Staging auth based on environment.
+    this.authEnvironment = 
+      (process.env.NODE_ENV && process.env.NODE_ENV == "production") ? 
+      AuthEnvironment.PROD : AuthEnvironment.STAGING;
 
-  private decodeToken(token: string) {
+    // TEMPORARY HARDCODE FOR LOCAL TESTING. REMOVE BEFORE MERGING.
+    // this.authEnvironment = AuthEnvironment.PROD;
+  }
+
+  private decodeToken(token: string): FirebaseJwtPayload {
     return jwtDecode(token) as FirebaseJwtPayload;
   }
 
-  private validateAccess(user: any, access?: Role[], fn?: ValidateCmp) {
+  private validateAccess(user: any, access?: Role[], fn?: ValidateCmp): boolean {
+    // If no access roles exist, then the route does not require authorization.
     if (!access) {
       return true;
     }
+
+    const privilege = this.extractUserPrivilege(user);
+
+    // Check that validation function passes for every role. 
     return access.every(
       fn ??
+        // Default validation function: check that role is either 'NONE' or privilege >= role.
         ((role) => {
-          if (role === Role.NONE && !user.privilege) {
+          if (role === Role.NONE) {
             return true;
           } else {
-            return user.privilege && user.privilege >= role;
+            return privilege && privilege >= role;
           }
         }),
     );
   }
 
-  extractAuthToken(token: string) {
-    if (token.startsWith("Bearer")) {
-      return token.replace("Bearer ", "");
-    }
-    return token;
+  // Extracts Firebase idtoken from the provided Bearer token by removing the 'Bearer' text if present.
+  extractAuthToken(token: string): string {
+    return token.startsWith("Bearer") ? token.replace("Bearer ", "") : token;
   }
 
   getJWTKeys() {
     return this.httpService.get(FirebaseAuthJWTKeySets);
   }
 
-  validateHttpUser(user: any, access?: Role[]) {
+  validateHttpUser(user: any, access?: Role[]): boolean {
     return this.validateAccess(user, access);
   }
 
-  intersectRoles(user: any, access?: Role[], fn?: ValidateFn) {
+  intersectRoles(user: any, access?: Role[], fn?: ValidateFn): boolean {
     return this.validateAccess(user, access, (role) => fn(user, role));
   }
 
-  // Only use for HTTP
-  validateRestrictedAccess(
+  // Only used for HTTP requests.
+  async validateRestrictedAccess(
     request: any,
     predicate?: RestrictedEndpointPredicate,
     access?: Role[],
-  ): boolean | undefined {
+  ): Promise<boolean> {
     if (!access || !predicate) {
-      // unable to determine access
-      return undefined;
+      // No predicated restrictions exist on this route, so block the request.
+      console.log("No predicate found.");
+      return false;
     }
 
-    const user = request.user;
-
-    // check for intersecting roles
-    if (user && user.privilege && !access.includes(user.privilege)) {
-      return undefined;
+    // Block the request if the user doesn't meet any of the predicated roles.
+    console.log(access);
+    const asfasdf = await this.getUserPrivilegeFromRequest(request);
+    console.log(asfasdf);
+    if (!access.includes(await this.getUserPrivilegeFromRequest(request))) {
+      console.log("Blocked on roles.");
+      return false;
     }
 
+    // Roles are a potential match, so check the predicate to determine access.
+    console.log("Checking predicate.");
     return predicate(request);
   }
 
   validateWsUser(token: string, access?: Role[]): boolean {
     const decodedToken = this.decodeToken(this.extractAuthToken(token));
-    if (decodedToken) {
-      return this.validateAccess(decodedToken, access);
+    if (!decodedToken) {
+      // Block the request if the decode process fails.
+      return false;
     }
-    return false;
+
+    return this.validateAccess(decodedToken, access);
   }
 
   async validateUser(uid: string): Promise<boolean> {
     return !!(await admin.auth().getUser(uid));
   }
 
-  async getUserPrivilege(uid: string): Promise<number> {
+  // Extract the user privilege from an HTTP Request.
+  async getUserPrivilegeFromRequest(request: any): Promise<number> {
+    return request.user ? this.extractUserPrivilege(request.user) : Role.NONE;
+  }
+
+  // Extract the user privilege from a decoded auth token or possibly other sources that fit the format.
+  extractUserPrivilege(user: any): number {
+    return user[this.authEnvironment] ?? Role.NONE;
+  }
+
+  // Look up a user's privilege in Firebase by their uid.
+  async getUserPrivilegeFromUid(uid: string): Promise<number> {
     try {
       if (await this.validateUser(uid)) {
         const user = await admin.auth().getUser(uid);
-        return user.customClaims.privilege;
+        console.log("Logging custom claims:")
+        console.log(user.customClaims);
+        return user.customClaims[this.authEnvironment];
       } else {
-        return 0;
+        return Role.NONE;
       }
     } catch (e) {
       console.error(e);
-      return 2;
+      return Role.TEAM;
     }
   }
 
-  updateUserClaims(uid: string, privilege: Role) {
-    return admin.auth().setCustomUserClaims(uid, { privilege });
+  // Update a user's Firebase custom claims to include the given privilege level.
+  async updateUserPrivilege(uid: string, privilege: Role): Promise<void> {
+    const privileges = ((await admin.auth().getUser(uid)).customClaims) ?? {};
+    privileges[this.authEnvironment] = privilege;
+    delete privileges.privilege;  // REMOVE BEFORE MERGING. REMOVES PREVIOUS SETUP.
+    await admin.auth().setCustomUserClaims(uid, privileges);
   }
 }

--- a/src/common/gcp/auth/firebase-auth.service.ts
+++ b/src/common/gcp/auth/firebase-auth.service.ts
@@ -87,7 +87,7 @@ export class FirebaseAuthService {
     }
 
     // Block the request if the user doesn't meet any of the predicated roles.
-    const asfasdf = await this.getUserPrivilegeFromRequest(request);
+    const user = await this.getUserPrivilegeFromRequest(request);
     if (!access.includes(await this.getUserPrivilegeFromRequest(request))) {
       return false;
     }

--- a/src/common/gcp/auth/firebase-auth.service.ts
+++ b/src/common/gcp/auth/firebase-auth.service.ts
@@ -12,7 +12,7 @@ import { Role } from "./firebase-auth.types";
 
 enum AuthEnvironment {
   PROD = "production",
-  STAGING = "staging"
+  STAGING = "staging",
 }
 
 type FirebaseJwtPayload = JwtPayload & { production?: number, staging?: number };
@@ -25,10 +25,11 @@ export class FirebaseAuthService {
   private authEnvironment: AuthEnvironment;
   
   constructor(private readonly httpService: HttpService, private readonly configService: ConfigService) {
-    this.authEnvironment = configService.get<AuthEnvironment>("AUTH_ENVIRONMENT");
-    if (!(this.authEnvironment in AuthEnvironment)) {
-      throw Error(`Unrecognized AUTH_ENVIRONMENT: ${this.authEnvironment}`);
+    const authEnv = configService.get<AuthEnvironment>("AUTH_ENVIRONMENT");
+    if (!Object.values(AuthEnvironment).includes(authEnv)) {
+      throw Error(`Unrecognized AUTH_ENVIRONMENT: ${authEnv}`);
     }
+    this.authEnvironment = authEnv;
   }
 
   private decodeToken(token: string): FirebaseJwtPayload {

--- a/src/common/gcp/auth/roles.guard.ts
+++ b/src/common/gcp/auth/roles.guard.ts
@@ -80,7 +80,6 @@ export class RolesGuard extends AuthGuard("jwt") {
 
     // if no authorization required default to passportAccess
     if (!restrictedRoles && !predicate && !rolesList) {
-      console.log("no auth required. defaulting to passport access");
       return true;
     }
 
@@ -120,18 +119,14 @@ export class RolesGuard extends AuthGuard("jwt") {
     } else if (context.getType() === "http") {
       // HTTP requests are checked against possible restricted roles
       const request = context.switchToHttp().getRequest();
-      console.log("logging user:");
-      console.log(request.user);
 
       // If the user is allowed without predicates, then let them pass.
       if (this.authService.validateHttpUser(request.user, rolesList)) {
-        console.log("Allowed without predicates.");
         return true;
       }
 
       // If route has special restrictions for lower permissions, then check the predicate.
       if (restricted) {
-        console.log("Checking restricted routes.");
         return this.authService.validateRestrictedAccess(
           request,
           restricted.predicate,
@@ -140,7 +135,6 @@ export class RolesGuard extends AuthGuard("jwt") {
       }
 
       // Otherwise, block the request.
-      console.log("No restrictions.");
       return false;
 
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { DocsModule } from "common/docs/docs.module";
 import { ConfigService } from "@nestjs/config";
 
 async function bootstrap() {
+  console.log(process.env.NODE_ENV);
   const app = await NestFactory.create(AppModule);
   const options = new DocumentBuilder()
     .setTitle("HackPSU Documentation")

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import { DocsModule } from "common/docs/docs.module";
 import { ConfigService } from "@nestjs/config";
 
 async function bootstrap() {
-  console.log(process.env.NODE_ENV);
   const app = await NestFactory.create(AppModule);
   const options = new DocumentBuilder()
     .setTitle("HackPSU Documentation")

--- a/src/modules/organizer/organizer.controller.ts
+++ b/src/modules/organizer/organizer.controller.ts
@@ -134,7 +134,7 @@ export class OrganizerController {
 
     const organizer = await this.organizerRepo.createOne(user).exec();
 
-    await this.auth.updateUserClaims(data.id, privilege);
+    await this.auth.updateUserPrivilege(data.id, privilege);
     this.socket.emit("create:organizer", organizer, SocketRoom.ADMIN);
 
     return organizer;
@@ -204,7 +204,7 @@ export class OrganizerController {
     let organizer = await this.organizerRepo.patchOne(id, rest).exec();
 
     if (privilege) {
-      await this.auth.updateUserClaims(id, privilege);
+      await this.auth.updateUserPrivilege(id, privilege);
     }
 
     this.socket.emit("update:organizer", organizer, SocketRoom.ADMIN);
@@ -247,7 +247,7 @@ export class OrganizerController {
     const { privilege, ...rest } = data;
     const organizer = await this.organizerRepo.replaceOne(id, rest).exec();
 
-    await this.auth.updateUserClaims(id, privilege);
+    await this.auth.updateUserPrivilege(id, privilege);
     this.socket.emit("update:organizer", organizer, SocketRoom.ADMIN);
 
     return this.organizerService.injectUserRoles([organizer]).pipe(take(1));
@@ -272,7 +272,7 @@ export class OrganizerController {
   async deleteOne(@Param("id") id: string) {
     const organizer = await this.organizerRepo.deleteOne(id).exec();
 
-    await this.auth.updateUserClaims(id, Role.NONE);
+    await this.auth.updateUserPrivilege(id, Role.NONE);
     this.socket.emit("delete:organizer", organizer, SocketRoom.ADMIN);
 
     return organizer;

--- a/src/modules/organizer/organizer.service.ts
+++ b/src/modules/organizer/organizer.service.ts
@@ -16,7 +16,7 @@ export class OrganizerService {
   injectUserRoles(organizers: Organizer[]) {
     return from(organizers).pipe(
       mergeMap((organizer) =>
-        from(this.auth.getUserPrivilege(organizer.id)).pipe(
+        from(this.auth.getUserPrivilegeFromUid(organizer.id)).pipe(
           map((privilege) => {
             organizer.privilege = privilege;
             return organizer;

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -198,7 +198,7 @@ export class UserController {
         .createOne({ ...data, resume: resumeUrl })
         .exec();
 
-      await this.auth.updateUserClaims(data.id, 0);
+      await this.auth.updateUserPrivilege(data.id, 0);
 
       this.socket.emit("create:user", user);
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -453,9 +453,9 @@ export class UserController {
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    // If we need to test emails locally, then comment out this if statement.
+    // If we need to test emails locally, then comment out this statement.
     // However, we don't really want to spam ourselves if we don't have to.
-    if (process.env.NODE_ENV && process.env.NODE_ENV == "production") {
+    if (process.env.RUNTIME_INSTANCE && process.env.RUNTIME_INSTANCE === "production") {
       const message = await this.sendGridService.populateTemplate(
         DefaultTemplate.registration,
         {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -16,23 +16,11 @@ export class UserService {
   }
 
   private get resumeBucket() {
-    if (process.env.NODE_ENV && process.env.NODE_ENV == "staging") {
-      return admin.storage().bucket();
-    } else {
-      return admin.storage().bucket(this.resumeBucketName);
-    }
-  }
-
-  private get prefix() {
-    if (process.env.NODE_ENV && process.env.NODE_ENV == "staging") {
-      return "resumes/";
-    } else {
-      return "";
-    }
+    return admin.storage().bucket(this.resumeBucketName);
   }
 
   private getResumeFileName(userId: string): string {
-    return `${this.prefix}${userId}.pdf`;
+    return `${userId}.pdf`;
   }
 
   private getAuthenticatedResumeUrl(filename: string): string {

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -7,7 +7,7 @@ import { FirebaseAuthModule, FirebaseConfig, Role } from "common/gcp";
 import { initializeApp } from "@firebase/app";
 import { User as FirebaseUser } from "@firebase/auth";
 import {
-  createUser,
+  createTestUser,
   deleteUser,
   fetchToken,
   promoteUser,
@@ -44,7 +44,7 @@ describe("UsersController (e2e)", () => {
 
     admin.initializeApp(options, appName);
 
-    user = await createUser();
+    user = await createTestUser();
   });
 
   beforeEach(async () => {

--- a/test/utils/auth-utils.ts
+++ b/test/utils/auth-utils.ts
@@ -1,14 +1,15 @@
-import { Role } from "common/gcp";
-import { nanoid } from "nanoid";
-import * as admin from "firebase-admin";
 import {
   getAuth,
   signInWithEmailAndPassword,
   getIdToken,
   User,
 } from "@firebase/auth";
+import * as admin from "firebase-admin";
+import { nanoid } from "nanoid";
 
-export async function createUser(privilege: Role = Role.TEAM) {
+import { Role } from "common/gcp";
+
+export async function createTestUser(privilege: Role = Role.TEAM) {
   const email = `test-user-${nanoid()}@email.com`;
   const password = nanoid();
 
@@ -18,7 +19,7 @@ export async function createUser(privilege: Role = Role.TEAM) {
   });
 
   await admin.auth().setCustomUserClaims(user.uid, {
-    privilege,
+    STAGING: Role.NONE
   });
 
   const userCredential = await signInWithEmailAndPassword(
@@ -36,7 +37,7 @@ export async function fetchToken(user: User) {
 
 export async function promoteUser(user: User, privilege: Role) {
   await admin.auth().setCustomUserClaims(user.uid, {
-    privilege,
+    STAGING: privilege,
   });
 }
 

--- a/test/utils/auth-utils.ts
+++ b/test/utils/auth-utils.ts
@@ -19,7 +19,7 @@ export async function createTestUser(privilege: Role = Role.TEAM) {
   });
 
   await admin.auth().setCustomUserClaims(user.uid, {
-    STAGING: Role.NONE
+    staging: Role.NONE
   });
 
   const userCredential = await signInWithEmailAndPassword(
@@ -37,7 +37,7 @@ export async function fetchToken(user: User) {
 
 export async function promoteUser(user: User, privilege: Role) {
   await admin.auth().setCustomUserClaims(user.uid, {
-    STAGING: privilege,
+    staging: privilege,
   });
 }
 


### PR DESCRIPTION
This PR properly sets up separate development and production environments to make testing easier (i.e. so we no longer have to test on prod). Since this was going to require some small auth changes anyways, I took this opportunity to (kinda) clean up some auth code as well.

The production and staging instances run on separate Cloud Run instances, but re-use the same Cloud SQL instance and simply use different databases within the same instance (because Cloud SQL is expensive on a per-instance basis). CI/CD through Github Actions is enabled, so the staging instance will auto-deploy upon pushing to the 'main' branch, and the production instance will auto-deploy upon pushing to the 'production' branch.

Access permission differences between the two are handled by having two sets of custom claims on each Firebase user: a 'production' set and a 'staging' set. A configurable environment variable tells the API which version to check when determining authorization. In previous iterations, we set up an entirely separate GCP and Firebase project to manage these separate auth instances. That technically made it easier to separate different auth environemnts, but had some overhead headache because the staging version didn't have billing enabled, which necessitated some weird checks in code, particularly in regards to storing files in buckets. This is why I have chosen to go this route.

There will be some migration associated with this, which needs to be handled _before_ merging this into production. Specifically, the current permissions system only includes a 'privilege' field in Firebase custom claims, and we now instead have 'production' and 'staging' versions, so every current user will need to be updated remove their current 'privilege' and transfer it to 'production'. I'll handle this in the coming days before this goes live in production.