### PR TITLE
Fix Google Wallet location

### DIFF
--- a/src/modules/wallet/wallet.controller.ts
+++ b/src/modules/wallet/wallet.controller.ts
@@ -54,8 +54,8 @@ export class WalletController {
       startDateTime: new Date(hackathon.startTime).toISOString(),
       endDateTime: new Date(hackathon.endTime).toISOString(),
       location: {
-        latitude: 40.48135,
-        longitude: -77.51559,
+        latitude: 40.803470,
+        longitude: -77.865478,
       },
     };
 


### PR DESCRIPTION
Got the location right. I think what was happening was that we were accidentally setting the location to be "Penn State University" as a whole instead of just the business building.