### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,6 +6,9 @@ on:
       - production
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy to Production


### PR DESCRIPTION
Potential fix for [https://github.com/Hack-PSU/apiv3/security/code-scanning/3](https://github.com/Hack-PSU/apiv3/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves actions like checking out the repository, authenticating with Google Cloud, and deploying a service, we will grant the minimal required permissions. Specifically:
- `contents: read` is needed for the `actions/checkout` step to read the repository contents.
- No other permissions are explicitly required for the GITHUB_TOKEN in this workflow.

The `permissions` block will be added at the root level of the workflow to apply to all jobs, ensuring consistency and minimal privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
