### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,5 +1,8 @@
 name: Deploy Staging API
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Hack-PSU/apiv3/security/code-scanning/2](https://github.com/Hack-PSU/apiv3/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file. This can be done at the top level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job, either location is acceptable, but the top level is preferred for clarity and future extensibility. The minimal required permission for this workflow is `contents: read`, as it does not interact with issues, pull requests, or require write access to repository contents. The change should be made at the top of the file, after the `name` field and before the `on` field, or immediately after the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
