### PR TITLE
line 17/18 of src/common/gcp/wallet/google-wallet.service.ts --> not …

### DIFF
--- a/src/common/gcp/wallet/google-wallet.service.ts
+++ b/src/common/gcp/wallet/google-wallet.service.ts
@@ -14,7 +14,8 @@ export class GoogleWalletService {
   constructor(private readonly configService: ConfigService) {
     // GOOGLE_APPLICATION_CREDENTIALS should point to your service account key file for local testing.
     this.keyFilePath = this.configService.get<string>(
-      "GOOGLE_APPLICATION_CREDENTIALS",
+      // "GOOGLE_APPLICATION_CREDENTIALS",
+      "GOOGLE_CERT",
     );
     this.init();
   }


### PR DESCRIPTION
NOT 'GOOGLE_APPLICATION_CREDENTIALS' but rather 'GOOGLE_CERT' in src/common/gcp/wallet/google-wallet.service.ts